### PR TITLE
Remove Epoch config and use on-chain values

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,22 +52,18 @@ period = "90s"
 uptime_threshold = 0.8
 
 [epochs]
-# start of the voting/mirroring epoch
-start = "2021-08-01T00:00:00Z"
-period = "180s"
 # first epoch to be voted for (do not leav this empty since the first epoch is well back in time
 first = 1111
 
 [voting_cronjob]
 enabled = false
 timeout = "10s"
-# voting contract address
-contract_address = "0x0000000"
 
 [mirroring_cronjob]
 enabled = false
 timeout = "10s"
-# mirroring contract address
-contract_address = "0x0000000"
-# address binder contract address
-address_binder_contract_address = "0x0000000"
+
+[contract_addresses]
+address_binder = "0x0000000"
+mirroring = "0x0000000"
+voting = "0x0000000"

--- a/config/config.go
+++ b/config/config.go
@@ -1,14 +1,13 @@
 package config
 
 import (
-	"flare-indexer/utils"
 	"fmt"
 	"log"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -69,9 +68,11 @@ func (cfg ChainConfig) GetPrivateKey() (string, error) {
 }
 
 type EpochConfig struct {
-	Period time.Duration   `toml:"period" envconfig:"EPOCH_PERIOD"`
-	Start  utils.Timestamp `toml:"start" envconfig:"EPOCH_TIME"`
-	First  int64           `toml:"first" envconfig:"EPOCH_FIRST"`
+	First int64 `toml:"first" envconfig:"EPOCH_FIRST"`
+}
+
+type ContractAddresses struct {
+	Voting common.Address `toml:"voting" envconfig:"VOTING_CONTRACT_ADDRESS"`
 }
 
 func ParseConfigFile(cfg interface{}, fileName string, allowMissing bool) error {

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -58,7 +58,7 @@ type UptimeConfig struct {
 type ContractAddresses struct {
 	config.ContractAddresses
 	AddressBinder common.Address `toml:"address_binder" envconfig:"ADDRESS_BINDER_CONTRACT_ADDRESS"`
-	Mirroring     common.Address `toml:"contract" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
+	Mirroring     common.Address `toml:"mirroring" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
 }
 
 func newConfig() *Config {

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -8,16 +8,17 @@ import (
 )
 
 type Config struct {
-	DB            config.DBConfig     `toml:"db"`
-	Logger        config.LoggerConfig `toml:"logger"`
-	Chain         config.ChainConfig  `toml:"chain"`
-	Metrics       MetricsConfig       `toml:"metrics"`
-	XChainIndexer IndexerConfig       `toml:"x_chain_indexer"`
-	PChainIndexer IndexerConfig       `toml:"p_chain_indexer"`
-	UptimeCronjob UptimeConfig        `toml:"uptime_cronjob"`
-	Mirror        MirrorConfig        `toml:"mirroring_cronjob"`
-	VotingCronjob VotingConfig        `toml:"voting_cronjob"`
-	Epochs        config.EpochConfig  `toml:"epochs"`
+	DB                config.DBConfig     `toml:"db"`
+	Logger            config.LoggerConfig `toml:"logger"`
+	Chain             config.ChainConfig  `toml:"chain"`
+	Metrics           MetricsConfig       `toml:"metrics"`
+	XChainIndexer     IndexerConfig       `toml:"x_chain_indexer"`
+	PChainIndexer     IndexerConfig       `toml:"p_chain_indexer"`
+	UptimeCronjob     UptimeConfig        `toml:"uptime_cronjob"`
+	Mirror            MirrorConfig        `toml:"mirroring_cronjob"`
+	VotingCronjob     VotingConfig        `toml:"voting_cronjob"`
+	Epochs            config.EpochConfig  `toml:"epochs"`
+	ContractAddresses ContractAddresses   `toml:"contract_addresses"`
 }
 
 type MetricsConfig struct {
@@ -40,13 +41,10 @@ type CronjobConfig struct {
 
 type MirrorConfig struct {
 	CronjobConfig
-	MirroringContract     common.Address `toml:"contract_address" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
-	AddressBinderContract common.Address `toml:"address_binder_contract_address" envconfig:"ADDRESS_BINDER_CONTRACT_ADDRESS"`
 }
 
 type VotingConfig struct {
 	CronjobConfig
-	ContractAddress common.Address `toml:"contract_address" envconfig:"VOTING_CONTRACT_ADDRESS"`
 }
 
 type UptimeConfig struct {
@@ -55,6 +53,12 @@ type UptimeConfig struct {
 	EnableVoting                   bool    `toml:"enable_voting"`
 	UptimeThreshold                float64 `toml:"uptime_threshold"`
 	DeleteOldUptimesEpochThreshold int64   `toml:"delete_old_uptimes_epoch_threshold"`
+}
+
+type ContractAddresses struct {
+	config.ContractAddresses
+	AddressBinder common.Address `toml:"address_binder" envconfig:"ADDRESS_BINDER_CONTRACT_ADDRESS"`
+	Mirroring     common.Address `toml:"contract" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
 }
 
 func newConfig() *Config {
@@ -79,9 +83,6 @@ func newConfig() *Config {
 		},
 		Chain: config.ChainConfig{
 			NodeURL: "http://localhost:9650/",
-		},
-		Epochs: config.EpochConfig{
-			Period: 90 * time.Second,
 		},
 	}
 }

--- a/indexer/cronjob/cronjob.go
+++ b/indexer/cronjob/cronjob.go
@@ -1,7 +1,6 @@
 package cronjob
 
 import (
-	globalConfig "flare-indexer/config"
 	"flare-indexer/database"
 	"flare-indexer/indexer/config"
 	"flare-indexer/logger"
@@ -58,11 +57,11 @@ type epochRange struct {
 	end   int64
 }
 
-func newEpochCronjob(cronjobCfg *config.CronjobConfig, epochCfg *globalConfig.EpochConfig) epochCronjob {
+func newEpochCronjob(cronjobCfg *config.CronjobConfig, epochs staking.EpochInfo) epochCronjob {
 	return epochCronjob{
 		enabled:   cronjobCfg.Enabled,
 		timeout:   cronjobCfg.Timeout,
-		epochs:    staking.NewEpochInfo(epochCfg),
+		epochs:    epochs,
 		batchSize: cronjobCfg.BatchSize,
 		delay:     cronjobCfg.Delay,
 	}

--- a/indexer/cronjob/mirror.go
+++ b/indexer/cronjob/mirror.go
@@ -42,6 +42,7 @@ type mirrorContracts interface {
 	) error
 	IsAddressRegistered(address string) (bool, error)
 	RegisterPublicKey(publicKey crypto.PublicKey) error
+	EpochConfig() (time.Time, time.Duration, error)
 }
 
 func NewMirrorCronjob(ctx indexerctx.IndexerContext) (Cronjob, error) {
@@ -56,8 +57,15 @@ func NewMirrorCronjob(ctx indexerctx.IndexerContext) (Cronjob, error) {
 		return nil, err
 	}
 
+	start, period, err := contracts.EpochConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	epochs := staking.NewEpochInfo(&cfg.Epochs, start, period)
+
 	mc := &mirrorCronJob{
-		epochCronjob: newEpochCronjob(&cfg.Mirror.CronjobConfig, &cfg.Epochs),
+		epochCronjob: newEpochCronjob(&cfg.Mirror.CronjobConfig, epochs),
 		db:           NewMirrorDBGorm(ctx.DB()),
 		contracts:    contracts,
 	}

--- a/indexer/cronjob/mirror.go
+++ b/indexer/cronjob/mirror.go
@@ -69,8 +69,10 @@ func NewMirrorCronjob(ctx indexerctx.IndexerContext) (Cronjob, error) {
 		db:           NewMirrorDBGorm(ctx.DB()),
 		contracts:    contracts,
 	}
-	mc.reset(ctx.Flags().ResetMirrorCronjob)
-	return mc, nil
+
+	err = mc.reset(ctx.Flags().ResetMirrorCronjob)
+
+	return mc, err
 }
 
 func (c *mirrorCronJob) Name() string {

--- a/indexer/cronjob/mirror_stubs.go
+++ b/indexer/cronjob/mirror_stubs.go
@@ -10,6 +10,7 @@ import (
 	"flare-indexer/utils/contracts/addresses"
 	"flare-indexer/utils/contracts/mirroring"
 	"flare-indexer/utils/contracts/voting"
+	"flare-indexer/utils/staking"
 	"math/big"
 	"time"
 
@@ -71,11 +72,11 @@ type mirrorContractsCChain struct {
 }
 
 func initMirrorJobContracts(cfg *config.Config) (mirrorContracts, error) {
-	if cfg.Mirror.MirroringContract == (common.Address{}) {
+	if cfg.ContractAddresses.Mirroring == (common.Address{}) {
 		return nil, errors.New("mirroring contract address not set")
 	}
 
-	if cfg.VotingCronjob.ContractAddress == (common.Address{}) {
+	if cfg.ContractAddresses.Voting == (common.Address{}) {
 		return nil, errors.New("voting contract address not set")
 	}
 
@@ -84,17 +85,17 @@ func initMirrorJobContracts(cfg *config.Config) (mirrorContracts, error) {
 		return nil, err
 	}
 
-	mirroringContract, err := mirroring.NewMirroring(cfg.Mirror.MirroringContract, eth)
+	mirroringContract, err := mirroring.NewMirroring(cfg.ContractAddresses.Mirroring, eth)
 	if err != nil {
 		return nil, err
 	}
 
-	votingContract, err := voting.NewVoting(cfg.VotingCronjob.ContractAddress, eth)
+	votingContract, err := voting.NewVoting(cfg.ContractAddresses.Voting, eth)
 	if err != nil {
 		return nil, err
 	}
 
-	addressBinderContract, err := addresses.NewBinder(cfg.Mirror.AddressBinderContract, eth)
+	addressBinderContract, err := addresses.NewBinder(cfg.ContractAddresses.AddressBinder, eth)
 	if err != nil {
 		return nil, err
 	}
@@ -148,4 +149,8 @@ func (m mirrorContractsCChain) RegisterPublicKey(publicKey crypto.PublicKey) err
 	}
 	_, err = m.addressBinder.RegisterAddresses(m.txOpts, publicKey.Bytes(), publicKey.Address(), ethAddress)
 	return err
+}
+
+func (m mirrorContractsCChain) EpochConfig() (start time.Time, period time.Duration, err error) {
+	return staking.GetEpochConfig(m.voting)
 }

--- a/indexer/cronjob/uptime_voting.go
+++ b/indexer/cronjob/uptime_voting.go
@@ -69,11 +69,17 @@ func NewUptimeVotingCronjob(ctx context.IndexerContext) (*uptimeVotingCronjob, e
 	}
 
 	config := ctx.Config().UptimeCronjob
+
+	start, period, err := staking.GetEpochConfig(votingContract)
+	if err != nil {
+		return nil, err
+	}
+
 	return &uptimeVotingCronjob{
 		epochCronjob: epochCronjob{
 			enabled: config.EnableVoting,
 			timeout: config.Timeout,
-			epochs:  staking.NewEpochInfo(&ctx.Config().UptimeCronjob.EpochConfig),
+			epochs:  staking.NewEpochInfo(&ctx.Config().UptimeCronjob.EpochConfig, start, period),
 		},
 		lastAggregatedEpoch:            -1,
 		deleteOldUptimesEpochThreshold: config.DeleteOldUptimesEpochThreshold,

--- a/indexer/cronjob/voting.go
+++ b/indexer/cronjob/voting.go
@@ -60,8 +60,15 @@ func NewVotingCronjob(ctx indexerctx.IndexerContext) (*votingCronjob, error) {
 		return nil, err
 	}
 
+	start, period, err := contract.EpochConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	epochs := staking.NewEpochInfo(&cfg.Epochs, start, period)
+
 	vc := &votingCronjob{
-		epochCronjob: newEpochCronjob(&cfg.VotingCronjob.CronjobConfig, &cfg.Epochs),
+		epochCronjob: newEpochCronjob(&cfg.VotingCronjob.CronjobConfig, epochs),
 		db:           db,
 		contract:     contract,
 	}

--- a/indexer/cronjob/voting_stubs.go
+++ b/indexer/cronjob/voting_stubs.go
@@ -4,6 +4,7 @@ import (
 	"flare-indexer/database"
 	"flare-indexer/indexer/config"
 	"flare-indexer/utils/contracts/voting"
+	"flare-indexer/utils/staking"
 	"math/big"
 	"time"
 
@@ -64,7 +65,7 @@ func newVotingContract(cfg *config.Config) (*voting.Voting, error) {
 	if err != nil {
 		return nil, err
 	}
-	return voting.NewVoting(cfg.VotingCronjob.ContractAddress, eth)
+	return voting.NewVoting(cfg.ContractAddresses.Voting, eth)
 }
 
 func (c *votingContractCChain) ShouldVote(epoch *big.Int) (bool, error) {
@@ -77,11 +78,5 @@ func (c *votingContractCChain) SubmitVote(epoch *big.Int, merkleRoot [32]byte) e
 }
 
 func (c *votingContractCChain) EpochConfig() (start time.Time, period time.Duration, err error) {
-	chainCfg, err := c.voting.GetEpochConfiguration(c.callOpts)
-	if err != nil {
-		return
-	}
-	start = time.Unix(chainCfg.FirstEpochStartTs.Int64(), 0)
-	period = time.Duration(chainCfg.EpochDurationSeconds.Int64()) * time.Second
-	return
+	return staking.GetEpochConfig(c.voting)
 }

--- a/indexer/cronjob/voting_test.go
+++ b/indexer/cronjob/voting_test.go
@@ -1,11 +1,10 @@
 package cronjob
 
 import (
-	globalConfig "flare-indexer/config"
 	"flare-indexer/database"
 	"flare-indexer/indexer/config"
 	"flare-indexer/indexer/pchain"
-	"flare-indexer/utils"
+	"flare-indexer/utils/staking"
 	"math/big"
 	"testing"
 	"time"
@@ -158,10 +157,10 @@ func initEpochCronjob() epochCronjob {
 		BatchSize: 5,
 	}
 
-	epochCfg := globalConfig.EpochConfig{
+	epochInfo := staking.EpochInfo{
 		Period: 180 * time.Second,
-		Start:  utils.Timestamp{Time: time.Now().Add(-time.Hour)},
+		Start:  time.Now().Add(-time.Hour),
 	}
 
-	return newEpochCronjob(&cronjobCfg, &epochCfg)
+	return newEpochCronjob(&cronjobCfg, epochInfo)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -120,3 +120,7 @@ func Info(msg string, args ...interface{}) {
 func Debug(msg string, args ...interface{}) {
 	sugar.Debugf(msg, args...)
 }
+
+func Fatal(msg string, args ...interface{}) {
+	sugar.Fatalf(msg, args...)
+}

--- a/services/config/config.go
+++ b/services/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	Chain             config.ChainConfig       `toml:"chain"`
 	Services          ServicesConfig           `toml:"services"`
 	Epochs            config.EpochConfig       `toml:"epochs"`
-	ContractAddresses config.ContractAddresses `toml:"contractAddresses"`
+	ContractAddresses config.ContractAddresses `toml:"contract_addresses"`
 }
 
 type ServicesConfig struct {

--- a/services/config/config.go
+++ b/services/config/config.go
@@ -2,18 +2,22 @@ package config
 
 import (
 	"flare-indexer/config"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type Config struct {
-	DB       config.DBConfig     `toml:"db"`
-	Logger   config.LoggerConfig `toml:"logger"`
-	Chain    config.ChainConfig  `toml:"chain"`
-	Services ServicesConfig      `toml:"services"`
-	Epochs   config.EpochConfig  `toml:"epochs"`
+	DB                config.DBConfig          `toml:"db"`
+	Logger            config.LoggerConfig      `toml:"logger"`
+	Chain             config.ChainConfig       `toml:"chain"`
+	Services          ServicesConfig           `toml:"services"`
+	Epochs            config.EpochConfig       `toml:"epochs"`
+	ContractAddresses config.ContractAddresses `toml:"contractAddresses"`
 }
 
 type ServicesConfig struct {
-	Address string `toml:"address"`
+	Address        string         `toml:"address"`
+	VotingContract common.Address `toml:"votingContract"`
 }
 
 func newConfig() *Config {

--- a/services/main/services.go
+++ b/services/main/services.go
@@ -5,7 +5,7 @@ import (
 	"flare-indexer/services/context"
 	"flare-indexer/services/routes"
 	"flare-indexer/services/utils"
-	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -17,8 +17,7 @@ import (
 func main() {
 	ctx, err := context.BuildContext()
 	if err != nil {
-		fmt.Printf("%v\n", err)
-		return
+		log.Fatal(err) // logger possibly not initialized here so use builtin log
 	}
 
 	muxRouter := mux.NewRouter()
@@ -27,7 +26,10 @@ func main() {
 	routes.AddStakerRoutes(router, ctx)
 	routes.AddTransactionRoutes(router, ctx)
 	routes.AddQueryRoutes(router, ctx)
-	routes.AddMirroringRoutes(router, ctx)
+
+	if err := routes.AddMirroringRoutes(router, ctx); err != nil {
+		logger.Fatal("Failed to add mirroring routes: %v", err)
+	}
 
 	router.Finalize()
 

--- a/services/routes/mirroring_test.go
+++ b/services/routes/mirroring_test.go
@@ -6,7 +6,6 @@ import (
 	"flare-indexer/services/api"
 	"flare-indexer/services/config"
 	serviceUtils "flare-indexer/services/utils"
-	"flare-indexer/utils"
 	"flare-indexer/utils/staking"
 	"net/http"
 	"net/http/httptest"
@@ -65,10 +64,10 @@ func TestGetMirroringData(t *testing.T) {
 func newMirroringTestRouteHandlers(txs map[string]database.PChainTxData) *mirroringRouteHandlers {
 	return &mirroringRouteHandlers{
 		db: newTestDB(txs),
-		epochs: staking.NewEpochInfo(&globalConfig.EpochConfig{
+		epochs: staking.EpochInfo{
 			Period: 180 * time.Second,
-			Start:  utils.Timestamp{Time: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)},
-		}),
+			Start:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
 	}
 }
 

--- a/utils/staking/epochs.go
+++ b/utils/staking/epochs.go
@@ -2,7 +2,10 @@ package staking
 
 import (
 	"flare-indexer/config"
+	"flare-indexer/utils/contracts/voting"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 type EpochInfo struct {
@@ -11,10 +14,10 @@ type EpochInfo struct {
 	First  int64
 }
 
-func NewEpochInfo(cfg *config.EpochConfig) EpochInfo {
+func NewEpochInfo(cfg *config.EpochConfig, start time.Time, period time.Duration) EpochInfo {
 	return EpochInfo{
-		Period: cfg.Period,
-		Start:  cfg.Start.Time,
+		Period: period,
+		Start:  start,
 		First:  cfg.First,
 	}
 }
@@ -33,4 +36,16 @@ func (e EpochInfo) GetTimeRange(epoch int64) (time.Time, time.Time) {
 
 func (e EpochInfo) GetEpochIndex(t time.Time) int64 {
 	return int64(t.Sub(e.Start) / e.Period)
+}
+
+func GetEpochConfig(votingContract *voting.Voting) (time.Time, time.Duration, error) {
+	chainCfg, err := votingContract.GetEpochConfiguration(&bind.CallOpts{})
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+
+	start := time.Unix(chainCfg.FirstEpochStartTs.Int64(), 0)
+	period := time.Duration(chainCfg.EpochDurationSeconds.Int64()) * time.Second
+
+	return start, period, nil
 }


### PR DESCRIPTION
Keep `first` epoch but remove the start and period values which can be retrieved from the voting contract.