### PR TITLE
Remove address binder address from config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,5 @@ enabled = false
 timeout = "10s"
 
 [contract_addresses]
-address_binder = "0x0000000"
 mirroring = "0x0000000"
 voting = "0x0000000"

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -57,8 +57,7 @@ type UptimeConfig struct {
 
 type ContractAddresses struct {
 	config.ContractAddresses
-	AddressBinder common.Address `toml:"address_binder" envconfig:"ADDRESS_BINDER_CONTRACT_ADDRESS"`
-	Mirroring     common.Address `toml:"mirroring" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
+	Mirroring common.Address `toml:"mirroring" envconfig:"MIRRORING_CONTRACT_ADDRESS"`
 }
 
 func newConfig() *Config {

--- a/indexer/cronjob/mirror_stubs.go
+++ b/indexer/cronjob/mirror_stubs.go
@@ -95,7 +95,7 @@ func initMirrorJobContracts(cfg *config.Config) (mirrorContracts, error) {
 		return nil, err
 	}
 
-	addressBinderContract, err := addresses.NewBinder(cfg.ContractAddresses.AddressBinder, eth)
+	addressBinderContract, err := newAddressBinderContract(eth, mirroringContract)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +116,17 @@ func initMirrorJobContracts(cfg *config.Config) (mirrorContracts, error) {
 		txOpts:        txOpts,
 		voting:        votingContract,
 	}, nil
+}
+
+func newAddressBinderContract(
+	eth *ethclient.Client, mirroringContract *mirroring.Mirroring,
+) (*addresses.Binder, error) {
+	addressBinderAddress, err := mirroringContract.AddressBinder(new(bind.CallOpts))
+	if err != nil {
+		return nil, err
+	}
+
+	return addresses.NewBinder(addressBinderAddress, eth)
 }
 
 func (m mirrorContractsCChain) GetMerkleRoot(epoch int64) ([32]byte, error) {


### PR DESCRIPTION
This config is not strictly needed when we can query the address from the mirroring contract instead.