### PR TITLE
Testing fixes

### DIFF
--- a/indexer/cronjob/address_binder.go
+++ b/indexer/cronjob/address_binder.go
@@ -1,0 +1,248 @@
+package cronjob
+
+import (
+	"flare-indexer/database"
+	indexerctx "flare-indexer/indexer/context"
+	"flare-indexer/logger"
+	"flare-indexer/utils"
+	"flare-indexer/utils/chain"
+	"flare-indexer/utils/staking"
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/pkg/errors"
+)
+
+const addressBinderStateName = "address_binder_cronjob"
+
+type addressBinderCronJob struct {
+	epochCronjob
+	db        addressBinderDB
+	contracts addressBinderContracts
+	time      utils.ShiftedTime
+}
+
+type addressBinderDB interface {
+	FetchState(name string) (database.State, error)
+	UpdateJobState(epoch int64, force bool) error
+	GetPChainTxsForEpoch(start, end time.Time) ([]database.PChainTxData, error)
+	GetPChainTx(txID string, address string) (*database.PChainTxData, error)
+}
+
+type addressBinderContracts interface {
+	GetMerkleRoot(epoch int64) ([32]byte, error)
+	IsAddressRegistered(address string) (bool, error)
+	RegisterPublicKey(publicKey crypto.PublicKey) error
+	EpochConfig() (time.Time, time.Duration, error)
+}
+
+func NewAddressBinderCronjob(ctx indexerctx.IndexerContext) (Cronjob, error) {
+	cfg := ctx.Config()
+
+	if !cfg.Mirror.Enabled {
+		return &addressBinderCronJob{}, nil
+	}
+
+	contracts, err := initAddressBinderJobContracts(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	start, period, err := contracts.EpochConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	epochs := staking.NewEpochInfo(&cfg.Mirror.EpochConfig, start, period)
+
+	mc := &addressBinderCronJob{
+		epochCronjob: newEpochCronjob(&cfg.Mirror.CronjobConfig, epochs),
+		db:           NewAddressBinderDBGorm(ctx.DB()),
+		contracts:    contracts,
+	}
+
+	err = mc.reset(ctx.Flags().ResetMirrorCronjob)
+
+	return mc, err
+}
+
+func (c *addressBinderCronJob) Name() string {
+	return "address_binder"
+}
+
+func (c *addressBinderCronJob) OnStart() error {
+	return nil
+}
+
+func (c *addressBinderCronJob) Call() error {
+	epochRange, err := c.getEpochRange()
+	if err != nil {
+		if errors.Is(err, errNoEpochsToRegisterAddresses) {
+			logger.Debug("no epochs to register addresses")
+			return nil
+		}
+
+		return err
+	}
+
+	logger.Debug("registering addresses for epochs %d-%d", epochRange.start, epochRange.end)
+	registered := mapset.NewSet[string]()
+	for epoch := epochRange.start; epoch <= epochRange.end; epoch++ {
+		logger.Debug("registering addresses for epoch %d", epoch)
+		if err := c.registerEpoch(registered, epoch); err != nil {
+			return err
+		}
+	}
+
+	logger.Debug("successfully registered addresses for epochs %d-%d", epochRange.start, epochRange.end)
+
+	if err := c.db.UpdateJobState(epochRange.end+1, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var errNoEpochsToRegisterAddresses = errors.New("no epochs to register addresses")
+
+func (c *addressBinderCronJob) getEpochRange() (*epochRange, error) {
+	startEpoch, err := c.getStartEpoch()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("start epoch: %d", startEpoch)
+
+	endEpoch, err := c.getEndEpoch(startEpoch)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("Registering addresses needed for epochs [%d, %d]", startEpoch, endEpoch)
+	return c.getTrimmedEpochRange(startEpoch, endEpoch), nil
+}
+
+func (c *addressBinderCronJob) getStartEpoch() (int64, error) {
+	jobState, err := c.db.FetchState(addressBinderStateName)
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(jobState.NextDBIndex), nil
+}
+
+func (c *addressBinderCronJob) getEndEpoch(startEpoch int64) (int64, error) {
+	currEpoch := c.epochs.GetEpochIndex(c.time.Now())
+	logger.Debug("current epoch: %d", currEpoch)
+
+	for epoch := currEpoch; epoch > startEpoch; epoch-- {
+		confirmed, err := c.isEpochConfirmed(epoch)
+		if err != nil {
+			return 0, err
+		}
+
+		if confirmed {
+			return epoch, nil
+		}
+	}
+
+	return 0, errNoEpochsToRegisterAddresses
+}
+
+func (c *addressBinderCronJob) isEpochConfirmed(epoch int64) (bool, error) {
+	merkleRoot, err := c.contracts.GetMerkleRoot(epoch)
+	if err != nil {
+		return false, errors.Wrap(err, "votingContract.GetMerkleRoot")
+	}
+
+	return merkleRoot != [32]byte{}, nil
+}
+
+func (c *addressBinderCronJob) registerEpoch(registered mapset.Set[string], epoch int64) error {
+	txs, err := c.getEpochTxs(epoch)
+	if err != nil {
+		return err
+	}
+
+	if len(txs) == 0 {
+		logger.Debug("no unregistered txs found")
+		return nil
+	}
+
+	logger.Info("registering %d txs", len(txs))
+	if err := c.registerTxs(registered, txs, epoch); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *addressBinderCronJob) getEpochTxs(epoch int64) ([]database.PChainTxData, error) {
+	startTimestamp, endTimestamp := c.epochs.GetTimeRange(epoch)
+
+	txs, err := c.db.GetPChainTxsForEpoch(startTimestamp, endTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	return staking.DedupeTxs(txs), nil
+}
+
+func (c *addressBinderCronJob) registerTxs(registered mapset.Set[string], txs []database.PChainTxData, epochID int64) error {
+	for _, tx := range txs {
+		if registered.Contains(tx.InputAddress) {
+			continue
+		}
+		if registered, err := c.registerAddress(*tx.TxID, tx.InputAddress); err != nil {
+			logger.Error("error registering address: %s", err.Error())
+		} else if registered {
+			logger.Info("registered address %s on address binder contract", tx.InputAddress)
+		}
+		registered.Add(tx.InputAddress)
+	}
+	return nil
+}
+
+// Return false if the address is already registered, true if it was registered successfully
+func (c *addressBinderCronJob) registerAddress(txID string, address string) (bool, error) {
+	registered, err := c.contracts.IsAddressRegistered(address)
+	if err != nil || registered {
+		return false, err
+	}
+	tx, err := c.db.GetPChainTx(txID, address)
+	if err != nil {
+		return false, err
+	}
+	if tx == nil {
+		return false, errors.New("tx not found")
+	}
+	publicKeys, err := chain.PublicKeysFromPChainBlock(tx.Bytes)
+	if err != nil {
+		return false, err
+	}
+	if tx.InputIndex >= uint32(len(publicKeys)) {
+		return false, errors.New("input index out of range")
+	}
+	publicKey := publicKeys[tx.InputIndex]
+	for _, k := range publicKey {
+		err := c.contracts.RegisterPublicKey(k)
+		if err != nil {
+			return false, errors.Wrap(err, "mirroringContract.RegisterPublicKey")
+		}
+	}
+	return true, nil
+}
+
+func (c *addressBinderCronJob) reset(firstEpoch int64) error {
+	if firstEpoch <= 0 {
+		return nil
+	}
+
+	logger.Info("Resetting address binder cronjob state to epoch %d", firstEpoch)
+	err := c.db.UpdateJobState(firstEpoch, true)
+	if err != nil {
+		return err
+	}
+	c.epochs.First = firstEpoch
+	return nil
+}

--- a/indexer/cronjob/cronjob.go
+++ b/indexer/cronjob/cronjob.go
@@ -13,6 +13,7 @@ type Cronjob interface {
 	Name() string
 	Enabled() bool
 	Timeout() time.Duration
+	RandomTimeoutDelta() time.Duration
 	Call() error
 	OnStart() error
 }
@@ -31,8 +32,9 @@ func RunCronjob(c Cronjob) {
 
 	logger.Debug("starting %s cronjob", c.Name())
 
-	ticker := time.NewTicker(c.Timeout())
-	for range ticker.C {
+	ticker := utils.NewRandomizedTicker(c.Timeout(), c.RandomTimeoutDelta())
+	for {
+		<-ticker
 		err := c.Call()
 		if err != nil {
 			logger.Error("%s cronjob error %s", c.Name(), err.Error())
@@ -73,6 +75,10 @@ func (c *epochCronjob) Enabled() bool {
 
 func (c *epochCronjob) Timeout() time.Duration {
 	return c.timeout
+}
+
+func (c *epochCronjob) RandomTimeoutDelta() time.Duration {
+	return 0
 }
 
 // Get processing range (closed interval)

--- a/indexer/cronjob/migrations.go
+++ b/indexer/cronjob/migrations.go
@@ -11,6 +11,8 @@ import (
 func init() {
 	migrations.Container.Add("2023-08-25-00-00", "Create initial state for voting cronjob", createVotingCronjobState)
 	migrations.Container.Add("2023-08-30-00-00", "Create initial state for mirror cronjob", createMirrorCronjobState)
+	migrations.Container.Add("2023-09-30-00-00", "Create initial state for address binder cronjob", createAddressBinderCronjobState)
+
 }
 
 func createVotingCronjobState(db *gorm.DB) error {
@@ -25,6 +27,15 @@ func createVotingCronjobState(db *gorm.DB) error {
 func createMirrorCronjobState(db *gorm.DB) error {
 	return database.CreateState(db, &database.State{
 		Name:           mirrorStateName,
+		NextDBIndex:    0,
+		LastChainIndex: 0,
+		Updated:        time.Now(),
+	})
+}
+
+func createAddressBinderCronjobState(db *gorm.DB) error {
+	return database.CreateState(db, &database.State{
+		Name:           addressBinderStateName,
 		NextDBIndex:    0,
 		LastChainIndex: 0,
 		Updated:        time.Now(),

--- a/indexer/cronjob/mirror_test.go
+++ b/indexer/cronjob/mirror_test.go
@@ -169,7 +169,7 @@ func TestMultipleTransactionsInSeparateEpochs(t *testing.T) {
 
 	db := testMirror(t, txsMap, contracts)
 
-	require.Equal(t, db.states[mirrorStateName].NextDBIndex, uint64(3))
+	require.Equal(t, db.states[mirrorStateName].NextDBIndex, uint64(4))
 }
 
 func TestAlreadyMirrored(t *testing.T) {
@@ -238,6 +238,10 @@ func testMirror(
 				LastChainIndex: 2,
 			},
 			mirrorStateName: {},
+			addressBinderStateName: {
+				Updated:     epochInfo.GetEndTime(999),
+				NextDBIndex: 4,
+			},
 		},
 		txs: txs,
 	}

--- a/indexer/cronjob/uptime.go
+++ b/indexer/cronjob/uptime.go
@@ -39,6 +39,10 @@ func (c *uptimeCronjob) Enabled() bool {
 	return c.config.Enabled
 }
 
+func (c *uptimeCronjob) RandomTimeoutDelta() time.Duration {
+	return 0
+}
+
 func (c *uptimeCronjob) OnStart() error {
 	entities := []*database.UptimeCronjob{&database.UptimeCronjob{
 		NodeID:    nil,

--- a/indexer/cronjob/voting.go
+++ b/indexer/cronjob/voting.go
@@ -88,6 +88,10 @@ func (c *votingCronjob) OnStart() error {
 	return nil
 }
 
+func (c *votingCronjob) RandomTimeoutDelta() time.Duration {
+	return 10 * time.Second
+}
+
 func (c *votingCronjob) Call() error {
 	idxState, err := c.db.FetchState(pchain.StateName)
 	if err != nil {

--- a/indexer/cronjob/voting_stubs.go
+++ b/indexer/cronjob/voting_stubs.go
@@ -3,7 +3,6 @@ package cronjob
 import (
 	"flare-indexer/database"
 	"flare-indexer/indexer/config"
-	"flare-indexer/logger"
 	"flare-indexer/utils/contracts/voting"
 	"flare-indexer/utils/staking"
 	"math/big"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
 
@@ -27,19 +25,8 @@ func (db *votingDBGorm) FetchPChainVotingData(start, end time.Time) ([]database.
 	return database.FetchPChainVotingData(db.g, start, end)
 }
 
-func (db *votingDBGorm) UpdateState(epoch int64, force bool) error {
-	return db.g.Transaction(func(tx *gorm.DB) error {
-		state, err := database.FetchState(tx, votingStateName)
-		if err != nil {
-			return errors.Wrap(err, "database.FetchState")
-		}
-		if !force && state.NextDBIndex >= uint64(epoch) {
-			logger.Debug("state already up to date")
-			return nil
-		}
-		state.NextDBIndex = uint64(epoch)
-		return database.UpdateState(tx, &state)
-	})
+func (db *votingDBGorm) UpdateState(state *database.State) error {
+	return database.UpdateState(db.g, state)
 }
 
 type votingContractCChain struct {

--- a/indexer/cronjob/voting_test.go
+++ b/indexer/cronjob/voting_test.go
@@ -37,16 +37,8 @@ func (db *votingDBTest) FetchPChainVotingData(start, end time.Time) ([]database.
 	return db.votingData[timeRange{start, end}], nil
 }
 
-func (db *votingDBTest) UpdateState(epoch int64, force bool) error {
-	if state, ok := db.states[votingStateName]; ok {
-		if !force && state.NextDBIndex >= uint64(epoch) {
-			return nil
-		}
-	}
-	db.states[votingStateName] = database.State{
-		Name:        votingStateName,
-		NextDBIndex: uint64(epoch),
-	}
+func (db *votingDBTest) UpdateState(state *database.State) error {
+	db.states[state.Name] = *state
 	return nil
 }
 

--- a/indexer/runner/runner.go
+++ b/indexer/runner/runner.go
@@ -16,6 +16,10 @@ func Start(ctx context.IndexerContext) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	addressBinderCronjob, err := cronjob.NewAddressBinderCronjob(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
 	mirrorCronjob, err := cronjob.NewMirrorCronjob(ctx)
 	if err != nil {
 		log.Fatal(err)
@@ -31,6 +35,7 @@ func Start(ctx context.IndexerContext) {
 
 	go cronjob.RunCronjob(uptimeCronjob)
 	go cronjob.RunCronjob(votingCronjob)
+	go cronjob.RunCronjob(addressBinderCronjob)
 	go cronjob.RunCronjob(mirrorCronjob)
 	go cronjob.RunCronjob(uptimeVotingCronjob)
 }

--- a/services/main/services.go
+++ b/services/main/services.go
@@ -25,7 +25,8 @@ func main() {
 	routes.AddTransferRoutes(router, ctx)
 	routes.AddStakerRoutes(router, ctx)
 	routes.AddTransactionRoutes(router, ctx)
-	routes.AddQueryRoutes(router, ctx)
+	// Disabled -- state connector routes are currently not used
+	// routes.AddQueryRoutes(router, ctx)
 
 	if err := routes.AddMirroringRoutes(router, ctx); err != nil {
 		logger.Fatal("Failed to add mirroring routes: %v", err)


### PR DESCRIPTION
The following things were changed:
-  Mirroring was split to address binding and to mirroring cronjobs; mirroring always follows address binding for the same epoch. This was necessary since mirroring immediately after binding (registering address) failed, because transaction with binding was not yet confirmed.
- I've randomized voting by adding a random number between 0 and 10 seconds to timeout. Since voters call shouldVote before sending a vote (shouldVote returns false if sufficient voters accepted the merkle root), those who are always late, do not participate in voting and do not spend any gas... Also, if they vote at the same time, transactions get reverted...