### PR TITLE
Include API key in RPC URL

### DIFF
--- a/indexer/cronjob/mirror_stubs.go
+++ b/indexer/cronjob/mirror_stubs.go
@@ -81,7 +81,7 @@ func initMirrorJobContracts(cfg *config.Config) (mirrorContracts, error) {
 		return nil, errors.New("voting contract address not set")
 	}
 
-	eth, err := ethclient.Dial(cfg.Chain.EthRPCURL)
+	eth, err := cfg.Chain.DialETH()
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/cronjob/uptime_voting.go
+++ b/indexer/cronjob/uptime_voting.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -59,7 +58,7 @@ func NewUptimeVotingCronjob(ctx context.IndexerContext) (*uptimeVotingCronjob, e
 		return &uptimeVotingCronjob{}, nil
 	}
 
-	eth, err := ethclient.Dial(cfg.Chain.EthRPCURL)
+	eth, err := cfg.Chain.DialETH()
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/cronjob/voting_stubs.go
+++ b/indexer/cronjob/voting_stubs.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"gorm.io/gorm"
 )
 
@@ -40,8 +39,7 @@ type votingContractCChain struct {
 }
 
 func newVotingContractCChain(cfg *config.Config) (votingContract, error) {
-
-	eth, err := ethclient.Dial(cfg.Chain.EthRPCURL)
+	eth, err := cfg.Chain.DialETH()
 	if err != nil {
 		return nil, err
 	}

--- a/services/context/context.go
+++ b/services/context/context.go
@@ -41,7 +41,7 @@ func BuildContext() (ServicesContext, error) {
 		return nil, err
 	}
 
-	ethRPCClient, err := ethclient.Dial(cfg.Chain.EthRPCURL)
+	ethRPCClient, err := cfg.Chain.DialETH()
 	if err != nil {
 		return nil, err
 	}

--- a/services/routes/mirroring.go
+++ b/services/routes/mirroring.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"gorm.io/gorm"
 )
 
@@ -66,7 +65,7 @@ func newMirroringRouteHandlers(ctx context.ServicesContext) (*mirroringRouteHand
 }
 
 func getEpochStartAndPeriod(cfg *config.Config) (time.Time, time.Duration, error) {
-	eth, err := ethclient.Dial(cfg.Chain.EthRPCURL)
+	eth, err := cfg.Chain.DialETH()
 	if err != nil {
 		return time.Time{}, 0, err
 	}


### PR DESCRIPTION
When configured, the API key for RPC nodes needs to be included as query param to the URL passed to ethclient.Dial(). Add common helper method to handle this.