### PR TITLE
Add new API route to list transactions for epoch

### DIFF
--- a/services/api/pchain.go
+++ b/services/api/pchain.go
@@ -67,3 +67,40 @@ func newApiPChainOutputs(inputs []database.PChainTxOutput) []ApiPChainTxOutput {
 	}
 	return result
 }
+
+type ApiPChainTxListItem struct {
+	Type         database.PChainTxType `json:"type"`
+	TxID         *string               `json:"txID"`
+	BlockHeight  uint64                `json:"blockHeight"`
+	ChainID      string                `json:"chainID"`
+	NodeID       string                `json:"nodeID"`
+	StartTime    *time.Time            `json:"startTime"`
+	EndTime      *time.Time            `json:"endTime"`
+	Weight       uint64                `json:"weight"`
+	InputAddress string                `json:"inputAddress"`
+	InputIndex   uint32                `json:"inputIndex"`
+}
+
+func newApiPChainTxListItem(tx *database.PChainTxData) ApiPChainTxListItem {
+	return ApiPChainTxListItem{
+		Type:         tx.Type,
+		TxID:         tx.TxID,
+		BlockHeight:  tx.BlockHeight,
+		ChainID:      tx.ChainID,
+		NodeID:       tx.NodeID,
+		StartTime:    tx.StartTime,
+		EndTime:      tx.EndTime,
+		Weight:       tx.Weight,
+		InputAddress: tx.InputAddress,
+		InputIndex:   tx.InputIndex,
+	}
+}
+
+func NewApiPChainTxList(txs []database.PChainTxData) []ApiPChainTxListItem {
+	result := make([]ApiPChainTxListItem, len(txs))
+	for i, tx := range txs {
+		result[i] = newApiPChainTxListItem(&tx)
+	}
+
+	return result
+}

--- a/services/main/services.go
+++ b/services/main/services.go
@@ -21,18 +21,21 @@ func main() {
 		log.Fatal(err) // logger possibly not initialized here so use builtin log
 	}
 
+	epochs, err := utils.NewEpochInfo(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	muxRouter := mux.NewRouter()
 	router := utils.NewSwaggerRouter(muxRouter, "Flare P-Chain Indexer", "0.1.0")
 	routes.AddTransferRoutes(router, ctx)
 	routes.AddStakerRoutes(router, ctx)
-	routes.AddTransactionRoutes(router, ctx)
+	routes.AddTransactionRoutes(router, ctx, epochs)
+	routes.AddMirroringRoutes(router, ctx, epochs)
 
 	// Disabled -- state connector routes are currently not used
 	// routes.AddQueryRoutes(router, ctx)
 
-	if err := routes.AddMirroringRoutes(router, ctx); err != nil {
-		logger.Fatal("Failed to add mirroring routes: %v", err)
-	}
 	router.Finalize()
 
 	cors := cors.New(cors.Options{

--- a/services/utils/epochs.go
+++ b/services/utils/epochs.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	globalconfig "flare-indexer/config"
+	"flare-indexer/services/config"
+	"flare-indexer/services/context"
+	"flare-indexer/utils/contracts/voting"
+	"flare-indexer/utils/staking"
+	"time"
+)
+
+func NewEpochInfo(ctx context.ServicesContext) (staking.EpochInfo, error) {
+	cfg := ctx.Config()
+
+	start, period, err := getEpochStartAndPeriod(cfg)
+	if err != nil {
+		return staking.EpochInfo{}, err
+	}
+
+	return staking.NewEpochInfo(&globalconfig.EpochConfig{}, start, period), nil
+}
+
+func getEpochStartAndPeriod(cfg *config.Config) (time.Time, time.Duration, error) {
+	eth, err := cfg.Chain.DialETH()
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+
+	votingContract, err := voting.NewVoting(cfg.ContractAddresses.Voting, eth)
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+
+	return staking.GetEpochConfig(votingContract)
+}


### PR DESCRIPTION
Added new API under existing transactions subrouter.

Exact requirements for what transaction data are needed for this API are unclear so may have to change, but for now just include the fields specified.

Pagination not yet implemented, can revisit if required.